### PR TITLE
Configure Azure Pipelines for MWC

### DIFF
--- a/.ci/release.yml
+++ b/.ci/release.yml
@@ -18,33 +18,33 @@ steps:
     condition:  and(succeeded(), contains(variables['Build.SourceBranch'], 'refs/tags/'), eq(variables['CI_JOB'], 'release' ))
     inputs:
       sourceFolder: '$(Build.SourcesDirectory)/target/release'
-      contents: 'grin-wallet'
-      targetFolder: '$(Build.BinariesDirectory)/grin-wallet'
+      contents: 'mwc-wallet'
+      targetFolder: '$(Build.BinariesDirectory)/mwc-wallet'
   - task: ArchiveFiles@2
     displayName: Gather assets
     condition:  and(succeeded(), contains(variables['Build.SourceBranch'], 'refs/tags/'), eq(variables['CI_JOB'], 'release' ))
     inputs:
-      rootFolderOrFile: '$(Build.BinariesDirectory)/grin-wallet'
+      rootFolderOrFile: '$(Build.BinariesDirectory)/mwc-wallet'
       archiveType: 'tar'
       tarCompression: 'gz'
-      archiveFile: '$(Build.ArtifactStagingDirectory)/grin-wallet-$(build.my_tag)-$(build.platform).tar.gz'
+      archiveFile: '$(Build.ArtifactStagingDirectory)/mwc-wallet-$(build.my_tag)-$(build.platform).tar.gz'
   - script: |
-      openssl sha256 $(Build.ArtifactStagingDirectory)/grin-wallet-$(build.my_tag)-$(build.platform).tar.gz > $(Build.ArtifactStagingDirectory)/grin-wallet-$(build.my_tag)-$(build.platform)-sha256sum.txt
+      openssl sha256 $(Build.ArtifactStagingDirectory)/mwc-wallet-$(build.my_tag)-$(build.platform).tar.gz > $(Build.ArtifactStagingDirectory)/mwc-wallet-$(build.my_tag)-$(build.platform)-sha256sum.txt
     displayName: Create Checksum
     condition:  and(succeeded(), contains(variables['Build.SourceBranch'], 'refs/tags/'), eq(variables['CI_JOB'], 'release' ))
   - task: GithubRelease@0
     displayName: Github release
     condition: and(succeeded(), startsWith(variables['Build.SourceBranch'], 'refs/tags/'), eq(variables['CI_JOB'], 'release' ))
     inputs:
-      gitHubConnection: 'ignopeverell'
-      repositoryName: 'mimblewimble/grin-wallet'
+      gitHubConnection: 'github-release'
+      repositoryName: 'mwcproject/mwc-wallet'
       action: 'edit'
       target: '$(build.sourceVersion)'
       tagSource: 'manual'
       tag: '$(build.my_tag)'
       assets: |
-        $(Build.ArtifactStagingDirectory)/grin-wallet-$(build.my_tag)-$(build.platform).tar.gz
-        $(Build.ArtifactStagingDirectory)/grin-wallet-$(build.my_tag)-$(build.platform)-sha256sum.txt
+        $(Build.ArtifactStagingDirectory)/mwc-wallet-$(build.my_tag)-$(build.platform).tar.gz
+        $(Build.ArtifactStagingDirectory)/mwc-wallet-$(build.my_tag)-$(build.platform)-sha256sum.txt
       title: '$(build.my_tag)'
       assetUploadMode: 'replace'
       addChangeLog: true

--- a/.ci/windows-release.yml
+++ b/.ci/windows-release.yml
@@ -19,32 +19,32 @@ steps:
     condition:  and(succeeded(), contains(variables['Build.SourceBranch'], 'refs/tags/'), eq(variables['CI_JOB'], 'release' ))
     inputs:
       sourceFolder: '$(Build.SourcesDirectory)\target\release'
-      contents: 'grin-wallet.exe'
-      targetFolder: '$(Build.BinariesDirectory)\grin-wallet'
+      contents: 'mwc-wallet.exe'
+      targetFolder: '$(Build.BinariesDirectory)\mwc-wallet'
   - task: ArchiveFiles@2
     displayName: Gather assets
     condition:  and(succeeded(), contains(variables['Build.SourceBranch'], 'refs/tags/'), eq(variables['CI_JOB'], 'release' ))
     inputs:
-      rootFolderOrFile: '$(Build.BinariesDirectory)\grin-wallet'
+      rootFolderOrFile: '$(Build.BinariesDirectory)\mwc-wallet'
       archiveType: 'zip'
-      archiveFile: '$(Build.ArtifactStagingDirectory)\grin-wallet-$(build.my_tag)-$(build.platform).zip'
+      archiveFile: '$(Build.ArtifactStagingDirectory)\mwc-wallet-$(build.my_tag)-$(build.platform).zip'
   - script: |
-      powershell -Command "get-filehash -algorithm sha256 $(Build.ArtifactStagingDirectory)\grin-wallet-$(build.my_tag)-$(build.platform).zip | Format-List |  Out-String | ForEach-Object { $_.Trim() } > $(Build.ArtifactStagingDirectory)\grin-wallet-$(build.my_tag)-$(build.platform)-sha256sum.txt"
+      powershell -Command "get-filehash -algorithm sha256 $(Build.ArtifactStagingDirectory)\mwc-wallet-$(build.my_tag)-$(build.platform).zip | Format-List |  Out-String | ForEach-Object { $_.Trim() } > $(Build.ArtifactStagingDirectory)\mwc-wallet-$(build.my_tag)-$(build.platform)-sha256sum.txt"
     displayName: Create Checksum
     condition:  and(succeeded(), contains(variables['Build.SourceBranch'], 'refs/tags/'), eq(variables['CI_JOB'], 'release' ))
   - task: GithubRelease@0
     displayName: Github release
     condition: and(succeeded(), startsWith(variables['Build.SourceBranch'], 'refs/tags/'), eq(variables['CI_JOB'], 'release' ))
     inputs:
-      gitHubConnection: 'ignopeverell'
-      repositoryName: 'mimblewimble/grin-wallet'
+      gitHubConnection: 'github-release'
+      repositoryName: 'mwcproject/mwc-wallet'
       action: 'edit'
       target: '$(build.sourceVersion)'
       tagSource: 'manual'
       tag: '$(build.my_tag)'
       assets: |
-        $(Build.ArtifactStagingDirectory)\grin-wallet-$(build.my_tag)-$(build.platform).zip
-        $(Build.ArtifactStagingDirectory)\grin-wallet-$(build.my_tag)-$(build.platform)-sha256sum.txt
+        $(Build.ArtifactStagingDirectory)\mwc-wallet-$(build.my_tag)-$(build.platform).zip
+        $(Build.ArtifactStagingDirectory)\mwc-wallet-$(build.my_tag)-$(build.platform)-sha256sum.txt
       title: '$(build.my_tag)'
       assetUploadMode: 'replace'
       addChangeLog: true

--- a/api/src/foreign_rpc.rs
+++ b/api/src/foreign_rpc.rs
@@ -359,7 +359,7 @@ pub trait ForeignRpc {
 
 	# Json rpc example
 
-	```
+	```rust,no_run
 	# grin_wallet_api::doctest_helper_json_rpc_foreign_assert_response!(
 	# r#"
 	{

--- a/api/src/owner_rpc.rs
+++ b/api/src/owner_rpc.rs
@@ -715,7 +715,7 @@ pub trait OwnerRpc {
 	/**
 	Networked version of [Owner::finalize_tx](struct.Owner.html#method.finalize_tx).
 
-	```
+	```rust,no_run
 	# grin_wallet_api::doctest_helper_json_rpc_owner_assert_response!(
 	# r#"
 	{
@@ -877,7 +877,7 @@ pub trait OwnerRpc {
 	/**
 	Networked version of [Owner::post_tx](struct.Owner.html#method.post_tx).
 
-	```
+	```rust,no_run
 	# grin_wallet_api::doctest_helper_json_rpc_owner_assert_response!(
 	# r#"
 	{

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -24,7 +24,7 @@ pr:
     include: ['*']
 
 variables:
-  RUST_BACKTRACE: '1'
+  RUST_BACKTRACE: 'FULL'
   RUST_FLAGS: '-C debug-assertions'
 
 jobs:


### PR DESCRIPTION
Azure Pipeline config updated. It _should_:
- Run tests on new commits or PRs
- Build and release on new tags (with sha256sums)
- Include Windows, Ubuntu, and OS X
- Produce full backtraces on errors