### PR TITLE
Cargo Doc Automation proposal

### DIFF
--- a/.ci/pushdocs.yml
+++ b/.ci/pushdocs.yml
@@ -1,10 +1,10 @@
 steps:
 - script: |
    cd /home/vsts/work/1/s/api && cargo fetch  && cargo doc --offline --no-deps
-   mkdir /home/vsts/work/1/gitpages && cd /home/vsts/work/1/gitpages && git clone https://anything:$(github_pat)@github.com/$(gh_user)/$(gh_repo).git .
+   mkdir /home/vsts/work/1/gitpages && cd /home/vsts/work/1/gitpages && git clone https://anything:$(github_pat)@github.com/$(ghpages_user)/$(ghpages_repo).git .
    
    cd  /home/vsts/work/1/gitpages
-   git config user.name $(gh_user)
+   git config user.name $(ghpages_user)
    git checkout master
    cp -a /home/vsts/work/1/s/target/doc/* /home/vsts/work/1/gitpages/
    echo '<meta http-equiv=refresh content=0;url=grin_wallet_api/trait.OwnerRpc.html>' > /home/vsts/work/1/gitpages/index.html && \
@@ -12,9 +12,9 @@ steps:
    git commit -m"Pipelines-Bot: Updated site via $(Build.SourceVersion)";
    git push https://$(github_pat)@github.com/mwcproject/mwcproject.github.io.git
    
-   curl https://api.github.com/repos/$(gh_user)/$(gh_repo)/pages/builds/latest -i -v \
+   curl https://api.github.com/repos/$(ghpages_user)/$(ghpages_repo)/pages/builds/latest -i -v \
        -X GET \
        -H "Accept: application/vnd.github.mister-fantastic-preview+json" \
-       -H "Authorization: Basic $(gh_auth_header)"
+       -H "Authorization: Basic $(ghpages_auth_header)"
   displayName: 'Create and Push Docs'
   condition: and(succeeded(), contains(variables['Build.SourceBranch'], 'refs/tags/'), eq(variables['CI_JOB'], 'release' ))

--- a/.ci/pushdocs.yml
+++ b/.ci/pushdocs.yml
@@ -1,0 +1,20 @@
+steps:
+- script: |
+   cd /home/vsts/work/1/s/api && cargo fetch  && cargo doc --offline --no-deps
+   mkdir /home/vsts/work/1/gitpages && cd /home/vsts/work/1/gitpages && git clone https://anything:$(github_pat)@github.com/$(gh_user)/$(gh_repo).git .
+   
+   cd  /home/vsts/work/1/gitpages
+   git config user.name $(gh_user)
+   git checkout master
+   cp -a /home/vsts/work/1/s/target/doc/* /home/vsts/work/1/gitpages/
+   echo '<meta http-equiv=refresh content=0;url=grin_wallet_api/trait.OwnerRpc.html>' > /home/vsts/work/1/gitpages/index.html && \
+   git add --all
+   git commit -m"Pipelines-Bot: Updated site via $(Build.SourceVersion)";
+   git push https://$(github_pat)@github.com/mwcproject/mwcproject.github.io.git
+   
+   curl https://api.github.com/repos/$(gh_user)/$(gh_repo)/pages/builds/latest -i -v \
+       -X GET \
+       -H "Accept: application/vnd.github.mister-fantastic-preview+json" \
+       -H "Authorization: Basic $(gh_auth_header)"
+  displayName: 'Create and Push Docs'
+  condition: and(succeeded(), contains(variables['Build.SourceBranch'], 'refs/tags/'), eq(variables['CI_JOB'], 'release' ))

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -33,6 +33,7 @@ variables:
   ghpages_auth_header: '$(echo -n "${ghpages_user}:$(github_pat)" | base64);'
 jobs:
 - job: linux
+  timeoutInMinutes: 120
   pool:
     vmImage: ubuntu-16.04
   strategy:
@@ -53,8 +54,8 @@ jobs:
     - template: '.ci/install.yml'
     - template: '.ci/test.yml'
     - template: '.ci/release.yml'
-
 - job: macos
+  timeoutInMinutes: 120
   pool:
     vmImage: macOS-latest
   strategy:
@@ -67,9 +68,9 @@ jobs:
   steps:
     - template: '.ci/install.yml'
     - template: '.ci/test.yml'
-    - template: '.ci/release.yml'
-    
+    - template: '.ci/release.yml' 
 - job: windows
+  timeoutInMinutes: 120
   pool:
     vmImage: windows-2019
   strategy:
@@ -83,8 +84,8 @@ jobs:
     - template: '.ci/install.yml'
     - template: '.ci/test.yml'
     - template: '.ci/windows-release.yml'
-    
 - job: Docs
+  timeoutInMinutes: 60
   pool:
     vmImage: ubuntu-16.04
   strategy:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -30,7 +30,7 @@ variables:
   RUSTFLAGS: '-C debug-assertions'
   ghpages_user: 'mwcproject'
   ghpages_repo: 'mwcproject.github.io'
-  ghpages_auth_header: '$(echo -n "${gh_user}:$(github_pat)" | base64);'
+  ghpages_auth_header: '$(echo -n "${ghpages_user}:$(github_pat)" | base64);'
 jobs:
 - job: linux
   pool:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -31,7 +31,7 @@ variables:
   gh_user: 'mwcproject'
   gh_repo: 'mwcproject.github.io'
   gh_auth_header: '$(echo -n "${gh_user}:$(github_pat)" | base64);'
-  
+
 jobs:
 - job: linux
  timeoutInMinutes: 120

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -57,7 +57,7 @@ jobs:
 
 - job: macos
   pool:
-    vmImage: macos-10.14
+    vmImage: macOS-latest
   strategy:
     matrix:
       test:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -31,7 +31,6 @@ variables:
   gh_user: 'mwcproject'
   gh_repo: 'mwcproject.github.io'
   gh_auth_header: '$(echo -n "${gh_user}:$(github_pat)" | base64);'
-
 jobs:
 - job: linux
  timeoutInMinutes: 120

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -17,6 +17,7 @@ trigger:
     include:
       - master
       - rebase3.0_withmwcmqs
+      
   tags:
     include: ['*']
 
@@ -27,10 +28,12 @@ pr:
 variables:
   RUST_BACKTRACE: '1'
   RUSTFLAGS: '-C debug-assertions'
-
+  gh_user: 'mwcproject'
+  gh_repo: 'mwcproject.github.io'
+  gh_auth_header: '$(echo -n "${gh_user}:$(github_pat)" | base64);'
+  
 jobs:
 - job: linux
-  timeoutInMinutes: 120
   pool:
     vmImage: ubuntu-16.04
   strategy:
@@ -51,10 +54,10 @@ jobs:
     - template: '.ci/install.yml'
     - template: '.ci/test.yml'
     - template: '.ci/release.yml'
+
 - job: macos
-  timeoutInMinutes: 120
   pool:
-    vmImage: macOS-latest
+    vmImage: macos-10.14
   strategy:
     matrix:
       test:
@@ -66,8 +69,8 @@ jobs:
     - template: '.ci/install.yml'
     - template: '.ci/test.yml'
     - template: '.ci/release.yml'
+    
 - job: windows
-  timeoutInMinutes: 120
   pool:
     vmImage: windows-2019
   strategy:
@@ -81,3 +84,15 @@ jobs:
     - template: '.ci/install.yml'
     - template: '.ci/test.yml'
     - template: '.ci/windows-release.yml'
+    
+- job: Docs
+  pool:
+    vmImage: ubuntu-16.04
+  strategy:
+    matrix:
+      release:
+        CI_JOB: release
+        PLATFORM: linux-amd64
+  steps:
+    - template: '.ci/install.yml'
+    - template: '.ci/pushdocs.yml'  

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -34,6 +34,7 @@ variables:
   
 jobs:
 - job: linux
+ timeoutInMinutes: 120
   pool:
     vmImage: ubuntu-16.04
   strategy:
@@ -56,6 +57,7 @@ jobs:
     - template: '.ci/release.yml'
 
 - job: macos
+ timeoutInMinutes: 120
   pool:
     vmImage: macOS-latest
   strategy:
@@ -71,6 +73,7 @@ jobs:
     - template: '.ci/release.yml'
     
 - job: windows
+ timeoutInMinutes: 120
   pool:
     vmImage: windows-2019
   strategy:
@@ -86,6 +89,7 @@ jobs:
     - template: '.ci/windows-release.yml'
     
 - job: Docs
+ timeoutInMinutes: 120
   pool:
     vmImage: ubuntu-16.04
   strategy:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -33,7 +33,6 @@ variables:
   gh_auth_header: '$(echo -n "${gh_user}:$(github_pat)" | base64);'
 jobs:
 - job: linux
- timeoutInMinutes: 120
   pool:
     vmImage: ubuntu-16.04
   strategy:
@@ -56,7 +55,6 @@ jobs:
     - template: '.ci/release.yml'
 
 - job: macos
- timeoutInMinutes: 120
   pool:
     vmImage: macOS-latest
   strategy:
@@ -72,7 +70,6 @@ jobs:
     - template: '.ci/release.yml'
     
 - job: windows
- timeoutInMinutes: 120
   pool:
     vmImage: windows-2019
   strategy:
@@ -88,7 +85,6 @@ jobs:
     - template: '.ci/windows-release.yml'
     
 - job: Docs
- timeoutInMinutes: 120
   pool:
     vmImage: ubuntu-16.04
   strategy:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -28,9 +28,9 @@ pr:
 variables:
   RUST_BACKTRACE: '1'
   RUSTFLAGS: '-C debug-assertions'
-  gh_user: 'mwcproject'
-  gh_repo: 'mwcproject.github.io'
-  gh_auth_header: '$(echo -n "${gh_user}:$(github_pat)" | base64);'
+  ghpages_user: 'mwcproject'
+  ghpages_repo: 'mwcproject.github.io'
+  ghpages_auth_header: '$(echo -n "${gh_user}:$(github_pat)" | base64);'
 jobs:
 - job: linux
   pool:


### PR DESCRIPTION
### Proposal to automate mwc-wallet Crate Documentation generated by rustdocs/Cargo doc

### **Preamble:**
It would be nice to automatically push new API Docs to Git Pages everytime a new mwc-wallet Build is released.
This can be accomplished by using an additional build step in Azure pipelines which creates the Docs, and then pushes them to the Gitpages Repo.

This PR has no Impact on Consensus or any actual Code that is connected to the Wallet itself. 
But it does hook into the CI Build process as its own Build Job, so it shouldn't matter if it would fail. 
Therefore the impact should be minimal.

If there are any questions or Inputs, please don't hesitate to give me a Tag.
Also take your time reviewing this as there is no haste to Push API docs out.

### **Approach/workflow:**
1. Execute Cargo Doc Command to generate Docs (only for API)
2. Clone current Git Pages Repo into extra Directory
3. Copy over Changed Docs (overwrite git pages repo locally)
4. Push Commit back to Git Pages Repo
5. Check if Github Pages Build was succesfull (so this check will fail if there is an Issue with Docs)
Im not totally sure if this check would actually get this step to fail (its the last command executed, returns a 200 code if AOK)
Step 5 might be unnecessarry/ineffective as Im not sure how long it takes for the build status to be returned.

### **Concerns/remarks:** 

**1.**  the Github Personal Access Token shouldn't be visible anywhere as far as I understand, no Log should mention it. 
I would love that double-checked however, mostly because it's connected to security. 

there is just 1 Command which stands out to me, which is 

`	"ghpages_auth_header: $(echo -n "${gpages_user}:$(github_pat)" | base64);"`

**2.**  I assume below condition is "ok" to use when we only want to push upon a new RELEASE (not just a draft version, draft release or anything)
The constraint is taken from https://github.com/mwcproject/mwc-node/blob/master/.ci/release.yml
	
`	condition: and(succeeded(), contains(variables['Build.SourceBranch'], 'refs/tags/'), eq(variables['CI_JOB'], 'release' ))`

**3.** Even if this Job would fail, it shouldn't Impact other Jobs in the pipeline, therefore this shouldn't interrupt the Build process overall


### **Needed actions to implement this PR/workflow:** 

1. Create PAT for user with push access to mwcproject.github.io
2. Save this personal Access token as a _secret_ variable in Azure (named %github_pat%)
3. (might not be needed) explicitly add the PAT user as a member to the mwcproject.github.io Repository where our Gitpages reside

4. Merge this PR and check if it build successfully upon next release 




### **Explanations of added Values:** 
 ` ghpages_user: 'mwcproject'   `(User of Github Pages Repository - the organization account)
`  ghpages_repo: 'mwcproject.github.io'` (Github Pages Repository - that pushed code will be pushed and then availlable via http at mwcproject.github.io)
  `ghpages_auth_header: '$(echo -n "${gh_user}:$(github_pat)" | base64);' `(This is needed to query the Github API to check if the Pages actually rendered.)


### **My test Environment can be found here:**

**Azure Log Output of the added Job =>** 
*edit:* Link removed since it's invalid now (azure didnt keep the logs so long) 

**Gitpages Repo:**
https://github.com/MrCryptoTtestpages/MrCryptoTtestpages.github.io
**Github Repo (my test branch)** 
https://github.com/MrCryptoT/mwc-wallet/tree/azuretesting2
**relevant yml files in my test branc:** 
https://github.com/MrCryptoT/mwc-wallet/blob/azuretesting2/azure-pipelines.yml
https://github.com/MrCryptoT/mwc-wallet/blob/azuretesting2/.ci/pushdocs.yml

### **Remark:**

> The example yml files in my Testenvironment contain my testbranches/usernames which IS NOT present in the PR, so they do slightly varry as they are configured for my test environment.
> For the actual content of the yml, please just check the PR content.


### **Sources:**

https://florian-rappl.de/News/Page/383/azure-pipelines-publish-to-github-pages
https://xaviergeerinck.com/post/infrastructure/deploying-gh-pages-with-azure-pipelines/
https://github.com/thebillkidy/thebillkidy.github.io/blob/development/azure-pipelines.yml


**If there are any questions, remarks or Feedback feel free to address those, Greetings MrT ☕** 