### PR TITLE
Fixes sending to Tor addresses with subdomains, paths, query strings, etc.

### DIFF
--- a/impls/src/adapters/http.rs
+++ b/impls/src/adapters/http.rs
@@ -380,11 +380,15 @@ impl SlateSender for HttpDataSender {
 	) -> Result<Option<(SlateVersion, Option<String>)>, Error> {
 		// we need to keep _tor in scope so that the process is not killed by drop.
 		let (url_str, _tor) = self.set_up_tor_send_process()?;
-		Ok(Some(self.check_other_version(
+		let (slate_version, slatepack_address) = self.check_other_version(
 			&url_str,
 			None,
 			destination_address,
-		)?))
+		)?;
+		if tor::status::get_tor_sender_running() {
+			tor::status::set_tor_sender_running(false);
+		}
+		Ok(Some((slate_version, slatepack_address)))
 	}
 
 	fn send_tx(

--- a/impls/src/tor/config.rs
+++ b/impls/src/tor/config.rs
@@ -312,10 +312,11 @@ pub fn is_tor_address(input: &str) -> Result<(), Error> {
 }
 
 pub fn complete_tor_address(input: &str) -> Result<String, Error> {
-	let input = if input.ends_with("/") {
-		&input[..input.len() - 1]
-	} else {
-		input
+	let (input, trailing_data) = match input.to_uppercase().find(".ONION") {
+		Some(index) => {
+			input.split_at(index + ".ONION".len())
+		}
+		None => (input, "")
 	};
 	is_tor_address(input)?;
 	let mut input = input.to_uppercase();
@@ -325,7 +326,7 @@ pub fn complete_tor_address(input: &str) -> Result<String, Error> {
 	if !input.ends_with(".ONION") {
 		input = format!("{}.ONION", input);
 	}
-	Ok(input.to_lowercase())
+	Ok(format!("{}{}", input.to_lowercase(), trailing_data))
 }
 
 #[cfg(test)]

--- a/impls/src/tor/config.rs
+++ b/impls/src/tor/config.rs
@@ -312,21 +312,28 @@ pub fn is_tor_address(input: &str) -> Result<(), Error> {
 }
 
 pub fn complete_tor_address(input: &str) -> Result<String, Error> {
-	let (input, trailing_data) = match input.to_uppercase().find(".ONION") {
+	let (subdomain, domain, trailing_data) = match input.to_uppercase().find(".ONION") {
 		Some(index) => {
-			input.split_at(index + ".ONION".len())
+			let (host, trailing_data) = input.split_at(index + ".ONION".len());
+			let (subdomain, domain) = match host[..host.len() - ".ONION".len()].rfind(".") {
+				Some(index) => {
+					host.split_at(index + ".".len())
+				}
+				None => ("", host)
+			};
+			(subdomain, domain, trailing_data)
 		}
-		None => (input, "")
+		None => ("", input, "")
 	};
-	is_tor_address(input)?;
-	let mut input = input.to_uppercase();
-	if !input.starts_with("HTTP://") && !input.starts_with("HTTPS://") {
-		input = format!("HTTP://{}", input);
+	is_tor_address(domain)?;
+	let mut domain = format!("{}{}", subdomain.to_uppercase(), domain.to_uppercase());
+	if !domain.starts_with("HTTP://") && !domain.starts_with("HTTPS://") {
+		domain = format!("HTTP://{}", domain);
 	}
-	if !input.ends_with(".ONION") {
-		input = format!("{}.ONION", input);
+	if !domain.ends_with(".ONION") {
+		domain = format!("{}.ONION", domain);
 	}
-	Ok(format!("{}{}", input.to_lowercase(), trailing_data))
+	Ok(format!("{}{}", domain.to_lowercase(), trailing_data))
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Fixes sending to Tor addresses that include a subdomain, port, path, query string, and/or fragment.

For example, this allows you to send to Tor addresses like this one:
http://www.example5yrphzqw5mlqfyrtltiw6lvu2bl6xvlrf2jvgztno2u3whqyd.onion:8080/path?foo=bar#test