### PR TITLE
Increase network read timeout when sending transactions

### DIFF
--- a/impls/src/node_clients/http.rs
+++ b/impls/src/node_clients/http.rs
@@ -105,7 +105,7 @@ impl HTTPNodeClient {
 		node_url_list: Vec<String>,
 		node_api_secret: Option<String>,
 	) -> Result<HTTPNodeClient, Error> {
-		let client = Client::new(false, None)
+		let client = Client::new(false, None, None)
 			.map_err(|e| Error::GenericError(format!("Unable to create a client, {}", e)))?;
 
 		Ok(HTTPNodeClient {


### PR DESCRIPTION
A followup to my previous pull request #15 that I accidentally closed by rebasing my fork.

These changes increase the network read timeout to 5 minutes when sending transactions to avoid timing out too early when exchanging a slate with a device that takes longer than a few seconds to generate a reply.

The 5 minute timeout is now only applied when sending a `receive_tx` request, and all other request types will still use the existing default read timeout. This will avoid any unnecessary waiting since a `check_version` request always comes before a `receive_tx` request.