### PR TITLE
Restart TOR when outage is detected

### DIFF
--- a/api/src/owner.rs
+++ b/api/src/owner.rs
@@ -746,7 +746,7 @@ where
 							})?;
 
 					let other_wallet_version = comm_adapter
-						.check_other_wallet_version(&sa.dest)
+						.check_other_wallet_version(&sa.dest, true)
 						.map_err(|e| {
 							Error::GenericError(format!("Unable to get other wallet info, {}", e))
 						})?;

--- a/config/src/config.rs
+++ b/config/src/config.rs
@@ -219,12 +219,12 @@ impl GlobalWalletConfig {
 			global::ChainTypes::Mainnet => {}
 			global::ChainTypes::Floonet => {
 				defaults.api_listen_port = 13415;
-				defaults.libp2p_listen_port = Some(13418);
+				defaults.libp2p_listen_port = None; // Some(13418);
 				defaults.check_node_api_http_addr = "http://127.0.0.1:13413".to_owned();
 			}
 			global::ChainTypes::UserTesting => {
 				defaults.api_listen_port = 23415;
-				defaults.libp2p_listen_port = Some(23418);
+				defaults.libp2p_listen_port = None; // Some(23418);
 				defaults.check_node_api_http_addr = "http://127.0.0.1:23413".to_owned();
 			}
 			_ => {}

--- a/config/src/types.rs
+++ b/config/src/types.rs
@@ -86,7 +86,7 @@ impl Default for WalletConfig {
 			chain_type: Some(ChainTypes::Mainnet),
 			api_listen_interface: "127.0.0.1".to_string(),
 			api_listen_port: 3415,
-			libp2p_listen_port: Some(3418),
+			libp2p_listen_port: None, //Some(3418),
 			owner_api_listen_port: Some(WalletConfig::default_owner_api_listen_port()),
 			api_secret_path: Some(".owner_api_secret".to_string()),
 			node_api_secret_path: Some(".api_secret".to_string()),

--- a/controller/src/command.rs
+++ b/controller/src/command.rs
@@ -540,7 +540,8 @@ where
 				"http" | "mwcmqs" => {
 					let sender =
 						create_sender(&args.method, &args.dest, &args.apisecret, tor_config)?;
-					let other_wallet_version = sender.check_other_wallet_version(&args.dest)?;
+					let other_wallet_version =
+						sender.check_other_wallet_version(&args.dest, true)?;
 					if let Some(other_wallet_version) = &other_wallet_version {
 						if init_args.target_slate_version.is_none() {
 							init_args.target_slate_version =
@@ -1428,7 +1429,7 @@ where
 						SlatePurpose::InvoiceResponse,
 						&slatepack_secret,
 						sender_pk,
-						sender.check_other_wallet_version(&args.dest)?,
+						sender.check_other_wallet_version(&args.dest, true)?,
 						height,
 						&secp,
 					)?;
@@ -4134,7 +4135,7 @@ where
 	let dest = format!("http://{}.onion", this_tor_address);
 
 	let sender = create_sender("tor", &dest, &None, Some(tor_config.clone()))?;
-	match sender.check_other_wallet_version(&dest) {
+	match sender.check_other_wallet_version(&dest, false) {
 		Ok(_) => println!("Tor connection online"),
 		Err(e) => println!("Tor is offline, {}", e),
 	}

--- a/controller/src/controller.rs
+++ b/controller/src/controller.rs
@@ -1151,7 +1151,8 @@ where
 
 		// checking connection every minute until the thread is running
 		if check_tor_connection {
-			if retries > 0 {
+			// After first restart no waiting, in most case it is a fix, so let's validata and report asap.
+			if retries > 1 {
 				// let's wait for some time.
 				for _ in 1..(60 * 2) {
 					if api_thread.is_finished() {

--- a/impls/src/adapters/http.rs
+++ b/impls/src/adapters/http.rs
@@ -120,6 +120,7 @@ impl HttpDataSender {
 		&self,
 		timeout: Option<u128>,
 		destination_address: &String,
+		show_error: bool,
 	) -> Result<(SlateVersion, Option<String>), Error> {
 		let res_str: String;
 		let start_time = std::time::Instant::now();
@@ -174,7 +175,11 @@ impl HttpDataSender {
 				          	Please urge the other wallet owner to upgrade and try the transaction again."
 						.to_string();
 				}
-				error!("{}", report);
+				if show_error {
+					error!("{}", report);
+				} else {
+					debug!("{}", report);
+				}
 				Error::ClientCallback(report)
 			})?;
 		}
@@ -433,9 +438,14 @@ impl SlateSender for HttpDataSender {
 	fn check_other_wallet_version(
 		&self,
 		destination_address: &String,
+		show_error: bool,
 	) -> Result<Option<(SlateVersion, Option<String>)>, Error> {
 		// we need to keep _tor in scope so that the process is not killed by drop.
-		Ok(Some(self.check_other_version(None, destination_address)?))
+		Ok(Some(self.check_other_version(
+			None,
+			destination_address,
+			show_error,
+		)?))
 	}
 
 	fn send_tx(

--- a/impls/src/adapters/mod.rs
+++ b/impls/src/adapters/mod.rs
@@ -46,6 +46,7 @@ pub trait SlateSender {
 	fn check_other_wallet_version(
 		&self,
 		destination_address: &String,
+		show_error: bool,
 	) -> Result<Option<(SlateVersion, Option<String>)>, Error>;
 
 	/// Send a transaction slate to another listening wallet and return result

--- a/impls/src/adapters/mwcmq.rs
+++ b/impls/src/adapters/mwcmq.rs
@@ -139,6 +139,7 @@ impl SlateSender for MwcMqsChannel {
 	fn check_other_wallet_version(
 		&self,
 		_destination_address: &String,
+		_show_error: bool,
 	) -> Result<Option<(SlateVersion, Option<String>)>, Error> {
 		Ok(None)
 	}


### PR DESCRIPTION
Restarting tor in case of outage. Improve reporting to the user. Listener reporting outage event and resuming event. Event like ping failure, retry failure goes into debug logs instead of warnings.
Tor restart really make sense. Tests shows that without restart tor outage window was 2-40 minutes long. Restarting allow to trade one 40 minutes outage to three outage each 2 minutes long. As result we have 6 minutes outage instead of 40 minutes