### PR TITLE
Split wallet locks for init_send_tx api. Add global lock for this api…

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3754,9 +3754,9 @@ version = "5.3.6"
 dependencies = [
  "base64 0.12.3",
  "chrono",
- "colored",
  "easy-jsonrpc-mwc",
  "ed25519-dalek",
+ "lazy_static",
  "log",
  "mwc_wallet_config",
  "mwc_wallet_impls",
@@ -3769,7 +3769,6 @@ dependencies = [
  "serde_json",
  "tempfile",
  "uuid",
- "x25519-dalek 0.6.0",
 ]
 
 [[package]]

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -20,9 +20,8 @@ chrono = { version = "0.4.11", features = ["serde"] }
 ring = "0.16"
 base64 = "0.12"
 ed25519-dalek = "1.0.0-pre.4"
-colored = "1.6"
-x25519-dalek = "0.6"
 easy-jsonrpc-mwc = { git = "https://github.com/mwcproject/easy-jsonrpc-mwc", version = "0.5.5", branch = "master" }
+lazy_static = "1.4"
 
 mwc_wallet_libwallet = { path = "../libwallet", version = "5.3.6" }
 mwc_wallet_config = { path = "../config", version = "5.3.6" }

--- a/api/src/lib.rs
+++ b/api/src/lib.rs
@@ -35,6 +35,8 @@ extern crate serde_json;
 
 #[macro_use]
 extern crate log;
+#[macro_use]
+extern crate lazy_static;
 
 mod foreign;
 mod foreign_rpc;


### PR DESCRIPTION
Split wallet locks for init_send_tx api. Add global lock for this api call, so send request processed sequentially.